### PR TITLE
Commit hook to bump db version on write [4/n]

### DIFF
--- a/cfsqlite.c
+++ b/cfsqlite.c
@@ -817,14 +817,13 @@ __declspec(dllexport)
                                  SQLITE_UTF8 | SQLITE_INNOCUOUS,
                                  0, dbVersionFunc, 0, 0);
   }
-  if (rc == SQLITE_OK) {
+  
+  if (rc == SQLITE_OK)
+  {
     // Only register a commit hook, not update or pre-update, since all rows in the same transaction
     // should have the same clock value.
     // This allows us to replicate them together and ensure more consistency.
     sqlite3_commit_hook(db, commitHook, 0);
-  }
-  if (rc == SQLITE_OK)
-  {
     rc = sqlite3_create_function(db, "cfsql", 1,
                                  // cfsql should only ever be used at the top level
                                  // and does a great deal to modify


### PR DESCRIPTION
The db version global always points to the next db version.

This means that all triggers can use the current value for their writes and on transaction commit, we'll bump the cached db version in preparation for the next write.


dbversion is an atomic int and threadsafe.

test plan:

```
sqlite> select cfsql_dbversion();
-9223372036854775806
sqlite> create table foo (a);
sqlite> select cfsql_dbversion();
-9223372036854775805
sqlite> insert into foo values (1);
sqlite> select cfsql_dbversion();
-9223372036854775804
```