### PR TITLE
[needs-review] bump db version in triggers rather than commit hook

### DIFF
--- a/cfsqlite-triggers.c
+++ b/cfsqlite-triggers.c
@@ -22,8 +22,9 @@ char *cfsql_conflictSetsStr(cfsql_ColumnInfo *cols, int len)
     if (cols[i].versionOf != 0)
     {
       sets[i] = sqlite3_mprintf(
-          "\"%s\" = CASE WHEN EXCLUDED.\"%s\" THEN \"%s\" + 1 ELSE \"%s\" END",
+          "\"%s\" = CASE WHEN EXCLUDED.\"%s\" != \"%s\" THEN \"%s\" + 1 ELSE \"%s\" END",
           cols[i].name,
+          cols[i].versionOf,
           cols[i].versionOf,
           cols[i].name,
           cols[i].name);

--- a/cfsqlite-triggers.c
+++ b/cfsqlite-triggers.c
@@ -107,7 +107,7 @@ char *cfsql_updateClocksStr(cfsql_TableInfo *tableInfo, int isDelete)
       "INSERT INTO \"%s__cfsql_clock\" (\"__cfsql_site_id\", \"__cfsql_version\", %s)\
       VALUES (\
         cfsql_siteid(),\
-        cfsql_dbversion(),\
+        cfsql_nextdbversion(),\
         %s\
       )\
       ON CONFLICT (\"__cfsql_site_id\", %s) DO UPDATE SET\
@@ -483,7 +483,6 @@ int cfsql_createPatchTrigger(
     cfsql_TableInfo *tableInfo,
     char **err)
 {
-
   char *zSql = cfsql_patchTriggerQuery(tableInfo);
   int rc = sqlite3_exec(db, zSql, 0, 0, err);
   sqlite3_free(zSql);

--- a/cfsqlite-triggers.h
+++ b/cfsqlite-triggers.h
@@ -27,5 +27,6 @@ char *cfsql_upTrigWhereConditions(cfsql_ColumnInfo *columnInfo, int len);
 char *cfsql_upTrigSets(cfsql_ColumnInfo *columnInfo, int len);
 int cfsql_createDeleteTrigger(sqlite3 *db, cfsql_TableInfo *tableInfo, char **err);
 char *cfsql_deleteTriggerQuery(cfsql_TableInfo *tableInfo);
+char *cfsql_conflictSetsStr(cfsql_ColumnInfo *cols, int len);
 
 #endif

--- a/cfsqlite-triggers.test.c
+++ b/cfsqlite-triggers.test.c
@@ -193,7 +193,7 @@ void testDeleteTriggerQuery()
       &errMsg);
 
   char *query = cfsql_deleteTriggerQuery(tableInfo);
-  assert(strcmp("CREATE TRIGGER \"foo__cfsql_dtrig\"    INSTEAD OF DELETE ON \"foo\"    BEGIN      UPDATE \"foo__cfsql_crr\" SET \"__cfsql_cl\" = \"__cfsql_cl\" + 1, \"__cfsql_src\" = 0 WHERE \"a\" = NEW.\"a\";            INSERT INTO \"foo__cfsql_clock\" (\"__cfsql_site_id\", \"__cfsql_version\", \"a\")      VALUES (        cfsql_siteid(),        cfsql_dbversion(),        OLD.\"a\"      )      ON CONFLICT (\"__cfsql_site_id\", \"a\") DO UPDATE SET        \"__cfsql_version\" = EXCLUDED.\"__cfsql_version\";        END", query) == 0);
+  assert(strcmp("CREATE TRIGGER \"foo__cfsql_dtrig\"    INSTEAD OF DELETE ON \"foo\"    BEGIN      UPDATE \"foo__cfsql_crr\" SET \"__cfsql_cl\" = \"__cfsql_cl\" + 1, \"__cfsql_src\" = 0 WHERE \"a\" = NEW.\"a\";            INSERT INTO \"foo__cfsql_clock\" (\"__cfsql_site_id\", \"__cfsql_version\", \"a\")      VALUES (        cfsql_siteid(),        cfsql_nextdbversion(),        OLD.\"a\"      )      ON CONFLICT (\"__cfsql_site_id\", \"a\") DO UPDATE SET        \"__cfsql_version\" = EXCLUDED.\"__cfsql_version\";        END", query) == 0);
 
   sqlite3_close(db);
   assert(rc == SQLITE_OK);

--- a/notes.md
+++ b/notes.md
@@ -1,5 +1,10 @@
 todo:
 
+- only allow single pk column?
+  - Otherwise we have to concat somehow.. and split back
+  - or no union query
+- select quote for dflt value from pragma? and extract as text?
+- incrementing causal length without looking is problematic for upserts
 - delta generation view?
   - Probs not if we want deltas across tables for cross table tx support.
   - Well we can get ids in a view since ids will union correctly.

--- a/notes.md
+++ b/notes.md
@@ -1,5 +1,9 @@
 todo:
 
+- rm commit hook
+  - we can't guarantee transactional replications anyhow -- no crdt system can even if they do replicate the tx rows as conflict
+    resolution will invalidate all tx guarantees.
+  -
 - only allow single pk column?
   - Otherwise we have to concat somehow.. and split back
   - or no union query
@@ -63,3 +67,5 @@ Delta Generation:
 Generate union query to grab primary keys from all tables where clock value > x.
 
 Big peer method:
+
+--


### PR DESCRIPTION
The code isn't so important -- mainly the idea needs review.

This gives each row that is touched a unique version which allows us to chunk the replication process.

If a bunch of rows have the same version we would need to ensure all of those rows are sent and applied
before moving to the next set of rows.

This is because peers keep track of what updates they have from other peers via peer version numbers.

If peer A sends version 10, skipping version 0-9, to peer B then peer B will never ask A for anything prior to 10.

I'm also skeptical that tagging all rows that are in a transaction with the same version actually accomplishes anything.
The idea behind tagging rows that are in the same transaction with the same version was to be able to try to maintain transaction gurantees.

While it would allow us to replicate all the rows that were touched by a transaction together, once state merging starts to happen any guarantess provided by that transaction are lost to the merge process.

This is because the peer being merged with could have updated fields on the same rows.

Another issue is that later transactions can occur which touch a subset of rows from prior transactions, causing the prior version number to get overwritten by the new transaction. Now when we try to replicate a transaction we'd actually only be replicating part of it since the other part had its version numbers changed.

todo: diagram this out.